### PR TITLE
Treat edge case for ignoring databases

### DIFF
--- a/src/permifrost/snowflake_spec_loader.py
+++ b/src/permifrost/snowflake_spec_loader.py
@@ -242,7 +242,11 @@ class SnowflakeSpecLoader:
         for missing_entity in missing_entities["dbs"]:
             click.secho(f"Ignored missing db {missing_entity}")
             self.entities["databases"].remove(missing_entity)
-            self.entities["database_refs"].remove(missing_entity)
+            
+            # Some listed databases might not be present in the database_refs list
+            if missing_entity in self.entities["database_refs"]:
+                self.entities["database_refs"].remove(missing_entity)
+            
             self.spec["databases"] = [
                 item
                 for item in self.spec["databases"]


### PR DESCRIPTION
If a database like snowflake_sample_data is listed in the spec, but not present in Snowflake or in any reference, this would cause an error.