### PR TITLE
Allow accountadmin role

### DIFF
--- a/src/permifrost/snowflake_spec_loader.py
+++ b/src/permifrost/snowflake_spec_loader.py
@@ -77,10 +77,10 @@ class SnowflakeSpecLoader:
         click.secho(f"  Current user is: {conn.get_current_user()}.", fg="green")
 
         current_role = conn.get_current_role()
-        if "securityadmin" != current_role:
+        if not current_role in ["securityadmin", "accountadmin"]:
             error_messages.append(
-                "Current role is not securityadmin! "
-                "Permifrost expects to run as securityadmin, please update your connection settings."
+                "Current role is not securityadmin or accountadmin! "
+                "Permifrost expects to run as securityadmin or accountadmin, please update your connection settings."
             )
         click.secho(f"  Current role is: {current_role}.", fg="green")
 


### PR DESCRIPTION
Snowflake gets stuck when showing grants of accountadmin when using securityadmin role.

This is a workaround to allow Permifrost to use accountadmin role too, so the command can be executed.