### PR TITLE
feat: Ignore temporary schemas ending with _next or _NEXT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Changelog](http://keepachangelog.com/).
 
 ### Fixes
 
+* **Schema inspection** - Ignore temporary schemas ending with _next or _NEXT to prevent intermittent errors when schemas disappear during execution. ([GEM-5](https://linear.app/gemma-analytics/issue/GEM-5), [#11](https://github.com/Gemma-Analytics/permifrost/pull/11))
+
 ### Changes
 
 ## 0.15.4 - (2023-12-04)

--- a/src/permifrost/snowflake_connector.py
+++ b/src/permifrost/snowflake_connector.py
@@ -148,7 +148,11 @@ class SnowflakeConnector:
         results = self.run_query(query).fetchall()
 
         for result in results:
-            schema_identifier = f"{result['database_name']}.{result['name']}"
+            schema_name = result["name"]
+            # Ignore temporary Snowflake schemas that end with _next or _NEXT
+            if schema_name.upper().endswith("_NEXT"):
+                continue
+            schema_identifier = f"{result['database_name']}.{schema_name}"
             names.append(SnowflakeConnector.snowflaky(schema_identifier))
 
         return names

--- a/tests/permifrost/test_snowflake_connector.py
+++ b/tests/permifrost/test_snowflake_connector.py
@@ -208,7 +208,7 @@ class TestSnowflakeConnector:
         )
         assert role == "test_role"
 
-    def test_show_schemas(self, mocker):
+    def test_show_schemas(self, mocker, snowflake_connector_env):
         mocker.patch("sqlalchemy.create_engine")
         conn = SnowflakeConnector()
         conn.run_query = mocker.MagicMock()
@@ -231,6 +231,35 @@ class TestSnowflakeConnector:
             "database_1.schema_1",
             'database_1."45_SCHEMA"',
             'database_1."CaseSensitiveSchema"',
+        ]
+
+    def test_show_schemas_filters_next_suffix(
+        self, mocker, snowflake_connector_env
+    ):
+        mocker.patch("sqlalchemy.create_engine")
+        conn = SnowflakeConnector()
+        conn.run_query = mocker.MagicMock()
+        mocker.patch.object(
+            conn.run_query(),
+            "fetchall",
+            return_value=[
+                {"database_name": "DATABASE_1", "name": "SCHEMA_1"},
+                {"database_name": "DATABASE_1", "name": "SCHEMA_1_next"},
+                {"database_name": "DATABASE_1", "name": "SCHEMA_2_NEXT"},
+                {"database_name": "DATABASE_1", "name": "SCHEMA_3_Next"},
+                {"database_name": "DATABASE_1", "name": "SCHEMA_4"},
+            ],
+        )
+
+        schemas = conn.show_schemas("database_1")
+
+        conn.run_query.assert_has_calls(
+            [mocker.call("SHOW TERSE SCHEMAS IN DATABASE database_1")]
+        )
+        # Should filter out schemas ending with _next, _NEXT, or _Next (case-insensitive)
+        assert schemas == [
+            "database_1.schema_1",
+            "database_1.schema_4",
         ]
 
     def test_show_tables(self, mocker):


### PR DESCRIPTION
## Summary

Fixes intermittent errors when temporary Snowflake schemas with `_next` suffix disappear during permifrost execution. Our ingestion framework creates temporary schemas with `_next` suffix (lower or upper case) that may be removed between when permifrost starts inspection and when it executes.

## Problem

When permifrost starts, it sees these temporary schemas and includes them in its execution plan. If the schema disappears before permifrost finishes (e.g., the ingestion run completes), permifrost errors with `object not exists` or similar errors.

## Solution

Filter out schemas ending with `_next` (case-insensitive) in `show_schemas()` — the central method called whenever permifrost needs to enumerate schemas in a database. This prevents temporary schemas from ever entering the execution plan.

## Changes

- **`src/permifrost/snowflake_connector.py`** — Added filtering in `show_schemas()` to skip schemas ending with `_NEXT` (case-insensitive check via `.upper().endswith("_NEXT")`)
- **`tests/permifrost/test_snowflake_connector.py`** — Added `test_show_schemas_filters_next_suffix()` covering `_next`, `_NEXT`, and `_Next` variants; also fixed missing `snowflake_connector_env` fixture on `test_show_schemas`

## Testing

- 20 unit tests passing (all existing + 1 new)
- New test verifies uppercase, lowercase, and mixed-case `_next` suffixes are all filtered
- Verified with flake8, black, and mypy — all clean

## Related

- Linear: [GEM-5](https://linear.app/gemma-analytics/issue/GEM-5/intermitent-snowflake-schemas-next-or-next-should-be-ignored)