### PR TITLE
fix: suppress SyntaxWarning flood from period-containing table names in snowflaky()

### DIFF
--- a/src/permifrost/snowflake_connector.py
+++ b/src/permifrost/snowflake_connector.py
@@ -380,9 +380,9 @@ class SnowflakeConnector:
 
         # We do not currently support identifiers that include periods (i.e. db_1.schema_1."table.with.period")
         if len(name_parts) > 3:
-            warnings.warn(
-                f"Unsupported object identifier: {name} contains additional periods within identifier.",
-                SyntaxWarning,
+            logger.debug(
+                "Unsupported object identifier: %s contains additional periods within identifier.",
+                name,
             )
 
         if len(name_parts) == 0:

--- a/tests/permifrost/test_snowflake_connector.py
+++ b/tests/permifrost/test_snowflake_connector.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import warnings
 
@@ -103,6 +104,17 @@ class TestSnowflakeConnector:
         )
 
         assert SnowflakeConnector.snowflaky(db19) == ""
+
+    def test_snowflaky_logs_debug_for_period_in_identifier(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="permifrost.logger"):
+            SnowflakeConnector.snowflaky(
+                'RAW_RESTRICTED.airbyte_internal."AIRBYTE_SFTP_raw__stream_2025-03-23.csv"'
+            )
+        assert any(
+            "contains additional periods" in r.message
+            for r in caplog.records
+            if r.levelno == logging.DEBUG
+        )
 
     def test_uses_oauth_if_available(self, mocker, snowflake_connector_env):
         mocker.patch("sqlalchemy.create_engine")

--- a/tests/permifrost/test_snowflake_connector.py
+++ b/tests/permifrost/test_snowflake_connector.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import pytest
 import sqlalchemy
@@ -91,7 +92,9 @@ class TestSnowflakeConnector:
             == 'database_1."1_LEADING_DIGIT".<table>'
         )
 
-        with pytest.warns(SyntaxWarning):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            # These identifiers have periods in them but should not raise SyntaxWarning anymore
             SnowflakeConnector.snowflaky(db16)
             SnowflakeConnector.snowflaky(db17)
 


### PR DESCRIPTION
## Summary

- Replaces `warnings.warn(..., SyntaxWarning)` with `logger.debug(...)` in `snowflaky()` for identifiers with more than 3 dot-separated parts
- Airbyte staging tables (e.g. `AIRBYTE_SFTP_raw__stream_2025-03-23.csv`) have periods in their names; each unique table name produced a distinct warning that bypassed Python's deduplication, flooding the interface with hundreds of lines per run
- Behaviour is unchanged — the function still returns a value for these identifiers; the information is now available at `DEBUG` log level instead of as a console warning

## Test Plan

- [ ] `uv run pytest -x --disable-pytest-warnings` — 240 tests pass
- [ ] `test_snowflaky` now uses `warnings.catch_warnings()` + `simplefilter("error")` to assert no `SyntaxWarning` fires for `db16`/`db17`
- [ ] `import warnings` retained in source (null-identifier branch at line ~389 still uses it)