### PR TITLE
fix: filter SHOW GRANTS TO USER to role grants only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Changelog](http://keepachangelog.com/).
 
 ### Fixes
 
+* **User role reconciliation** - `SHOW GRANTS TO USER` now filters to `granted_on == 'ROLE'` rows. Modern Snowflake auto-creates a per-user database (`USER$<NAME>`, from Snowsight Workspaces), which adds privilege rows (with an empty `role` column) to the grant listing. Reading `role` on those rows produced invalid `REVOKE ROLE  FROM user <name>;` SQL that broke reconciliation on any account with per-user databases.
+
 * **Schema inspection** - Ignore temporary schemas ending with _next or _NEXT to prevent intermittent errors when schemas disappear during execution. ([GEM-5](https://linear.app/gemma-analytics/issue/GEM-5), [#11](https://github.com/Gemma-Analytics/permifrost/pull/11))
 
 ### Changes

--- a/src/permifrost/snowflake_connector.py
+++ b/src/permifrost/snowflake_connector.py
@@ -272,6 +272,15 @@ class SnowflakeConnector:
         results = self.run_query(query).fetchall()
 
         for result in results:
+            # Only consider actual role grants. Modern Snowflake auto-creates a
+            # per-user database (USER$<NAME>, from Snowsight Workspaces) for any
+            # user who has used the UI, and SHOW GRANTS TO USER then returns
+            # privilege rows (e.g. USAGE / CREATE SCHEMA / OWNERSHIP on
+            # USER$<NAME> objects) alongside the real ROLE grants. Those
+            # privilege rows have an empty "role" column, which would otherwise
+            # produce invalid "REVOKE ROLE  FROM user ..." SQL downstream.
+            if result["granted_on"] != "ROLE":
+                continue
             roles.append(SnowflakeConnector.snowflaky(result["role"]))
 
         return roles

--- a/tests/permifrost/test_snowflake_connector.py
+++ b/tests/permifrost/test_snowflake_connector.py
@@ -277,6 +277,56 @@ class TestSnowflakeConnector:
             "database_1.schema_4",
         ]
 
+    def test_show_roles_granted_to_user_ignores_non_role_grants(
+        self, mocker, snowflake_connector_env
+    ):
+        # Modern Snowflake auto-creates a per-user database (USER$<NAME>, from
+        # Snowsight Workspaces). SHOW GRANTS TO USER then returns privilege rows
+        # on those objects (with an empty "role" column) alongside the real ROLE
+        # grants. Those privilege rows must be filtered out, otherwise the empty
+        # role name produces invalid "REVOKE ROLE  FROM user ..." SQL downstream.
+        mocker.patch("sqlalchemy.create_engine")
+        conn = SnowflakeConnector()
+        conn.run_query = mocker.MagicMock()
+        mocker.patch.object(
+            conn.run_query(),
+            "fetchall",
+            return_value=[
+                {
+                    "granted_on": "ROLE",
+                    "role": "ACCOUNTADMIN",
+                    "grantee_name": "TEST_USER",
+                },
+                {
+                    "granted_on": "DATABASE",
+                    "role": "",
+                    "name": "USER$TEST_USER",
+                    "grantee_name": "TEST_USER",
+                },
+                {
+                    "granted_on": "SCHEMA",
+                    "role": "",
+                    "name": "USER$TEST_USER.PUBLIC",
+                    "grantee_name": "TEST_USER",
+                },
+                {
+                    "granted_on": "WORKSPACE",
+                    "role": "",
+                    "name": "USER$TEST_USER.PUBLIC.DEFAULT$",
+                    "grantee_name": "TEST_USER",
+                },
+            ],
+        )
+
+        roles = conn.show_roles_granted_to_user("test_user")
+
+        conn.run_query.assert_has_calls(
+            [mocker.call("SHOW GRANTS TO USER test_user")]
+        )
+        # Only the actual ROLE grant is returned; the per-user database
+        # privilege rows are ignored.
+        assert roles == ["accountadmin"]
+
     def test_show_tables(self, mocker):
         mocker.patch("sqlalchemy.create_engine")
         conn = SnowflakeConnector()
@@ -499,7 +549,7 @@ class TestSnowflakeConnector:
         assert roles['"ROLE WITH SPACES"'] == "superadmin"
         assert roles['"lowercase role with spaces"'] == "superadmin"
 
-    def test_show_roles_granted_to_user(self, mocker):
+    def test_show_roles_granted_to_user(self, mocker, snowflake_connector_env):
         mocker.patch("sqlalchemy.create_engine")
         conn = SnowflakeConnector()
         conn.run_query = mocker.MagicMock()
@@ -507,10 +557,10 @@ class TestSnowflakeConnector:
             conn.run_query(),
             "fetchall",
             return_value=[
-                {"role": "TEST_ROLE"},
-                {"role": "SUPERADMIN"},
-                {"role": "ROLE WITH SPACES"},
-                {"role": "lowercase role with spaces"},
+                {"granted_on": "ROLE", "role": "TEST_ROLE"},
+                {"granted_on": "ROLE", "role": "SUPERADMIN"},
+                {"granted_on": "ROLE", "role": "ROLE WITH SPACES"},
+                {"granted_on": "ROLE", "role": "lowercase role with spaces"},
             ],
         )
 


### PR DESCRIPTION
## Symptom

`permifrost` / `tundri run` fails during user role reconciliation with a SQL compilation error caused by an empty role name:

```sql
REVOKE ROLE  FROM user bijan_soltani;
```

This breaks reconciliation on **any** account with per-user databases — i.e. every client on a modern Snowflake account.

## Root cause

`show_roles_granted_to_user()` runs `SHOW GRANTS TO USER <user>` and appends `result["role"]` for every returned row.

Modern Snowflake auto-creates a per-user database `USER$<NAME>` (Snowsight Workspaces) for any user who has used the UI. `SHOW GRANTS TO USER` then returns **privilege** grants on those objects alongside the real ROLE grants. Real observed output for one user:

```
privilege      granted_on   name                              grantee_name
USAGE          ROLE         ACCOUNTADMIN                      BIJAN_SOLTANI   <- the only real role grant
CREATE SCHEMA  DATABASE     USER$BIJAN_SOLTANI                BIJAN_SOLTANI
USAGE          DATABASE     USER$BIJAN_SOLTANI                BIJAN_SOLTANI
OWNERSHIP      SCHEMA       USER$BIJAN_SOLTANI.LOCAL          BIJAN_SOLTANI
OWNERSHIP      SCHEMA       USER$BIJAN_SOLTANI.PUBLIC         BIJAN_SOLTANI
OWNERSHIP      WORKSPACE    USER$BIJAN_SOLTANI.PUBLIC.DEFAULT$ BIJAN_SOLTANI
```

The privilege rows have an **empty `role` column**, so the function appended empty role names. Downstream (`REVOKE_ROLE_TEMPLATE = "REVOKE ROLE {role_name} FROM {type} {entity_name}"`) that yields the invalid `REVOKE ROLE  FROM user ...;` SQL above.

## Fix

In `show_roles_granted_to_user` (`src/permifrost/snowflake_connector.py`), filter to rows where `granted_on == "ROLE"` — the authoritative signal for an actual role grant. This mirrors the existing `grant_to == "ROLE"` pattern in `show_future_grants()` and the `granted_on` column access used across the other `SHOW GRANTS`-parsing functions in the same file.

## Tests

- Added `test_show_roles_granted_to_user_ignores_non_role_grants`, which feeds a `SHOW GRANTS TO USER` result containing the per-user `USER$<NAME>` DATABASE/SCHEMA/WORKSPACE privilege rows and asserts only the real `ROLE` grant is returned.
- Updated the existing `test_show_roles_granted_to_user` fixture rows to include the `granted_on: "ROLE"` column (present in real Snowflake output).

All 22 tests in `tests/permifrost/test_snowflake_connector.py` pass.

## Downstream follow-up (to ship to clients)

This library is consumed by `tundri` (which depends on the `gemma.permifrost` PyPI package, unpinned). To roll out:

1. Merge this PR.
2. Cut a new `gemma.permifrost` release — this repo releases via a PR that bumps the `VERSION` file (see `.github/workflows/release.yml` and `GEMMA_RELEASE.md`), which triggers the PyPI publish. No hand version bump is included in this PR.
3. Release a new `tundri` version so its `gemma.permifrost` resolution picks up the fix (and pin it if desired).
4. Clients bump their `requirements.txt` to the new `tundri`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)